### PR TITLE
Improve diff performance with concurrency

### DIFF
--- a/src/core/comparator.ts
+++ b/src/core/comparator.ts
@@ -1,11 +1,10 @@
-/* eslint-disable no-await-in-loop */
 import {diffWords} from 'diff';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import pixelmatch from 'pixelmatch';
 import {PNG} from 'pngjs';
 
-import {generateHtmlReport} from './reporter.js';
+import {generateHtmlReport, type PageResult} from './reporter.js';
 
 interface PageData {
   html: string;
@@ -65,10 +64,12 @@ export async function compareSites(
   testPages: SitePages,
   options: CompareOptions = {}
 ) {
-  const results = [];
+  const results: PageResult[] = [];
   await fs.mkdir('diff_output', {recursive: true});
 
-  for (const pathKey of Object.keys(prodPages)) {
+  const keys = Object.keys(prodPages);
+
+  await Promise.all(keys.map(async pathKey => {
     const prod = prodPages[pathKey];
     const test = testPages[pathKey];
 
@@ -145,7 +146,7 @@ export async function compareSites(
         visualDiff: visualDiffPercent,
       });
     }
-  }
+  }));
 
   await generateHtmlReport(results, 'report.html', options.htmlThreshold ?? 0);
 }

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -1,28 +1,43 @@
 /* eslint-disable no-await-in-loop */
 import {chromium} from 'playwright';
 
-export async function fetchPages(baseUrl: string, paths: string[], logFn: (msg: string) => void) {
+export async function fetchPages(
+  baseUrl: string,
+  paths: string[],
+  logFn: (msg: string) => void,
+  concurrency = 4,
+) {
   const browser = await chromium.launch();
   const context = await browser.newContext();
-  const page = await context.newPage();
-  page.setDefaultNavigationTimeout(60_000); // 60 seconds
 
   const results: Record<string, {html: string; screenshot: Buffer}> = {};
+  const queue = [...paths];
 
-  for (const path of paths) {
-    const fullUrl = path.startsWith('http') ? path : `${baseUrl}${path}`;
-    logFn(`Fetching ${fullUrl}`);
+  async function worker() {
+    const page = await context.newPage();
+    page.setDefaultNavigationTimeout(60_000); // 60 seconds
 
-    try {
-      await page.goto(fullUrl, {waitUntil: 'networkidle'});
-      const html = await page.content();
-      const screenshot = await page.screenshot({fullPage: true});
-      results[path] = {html, screenshot};  // ✅ Use `path` as key
-      logFn(`Fetched and stored content for ${path}`);
-    } catch (error) {
-      logFn(`Error fetching ${fullUrl}: ${error}`);
+    while (queue.length > 0) {
+      const nextPath = queue.shift();
+      if (!nextPath) break;
+      const fullUrl = nextPath.startsWith('http') ? nextPath : `${baseUrl}${nextPath}`;
+      logFn(`Fetching ${fullUrl}`);
+
+      try {
+        await page.goto(fullUrl, {waitUntil: 'networkidle'});
+        const html = await page.content();
+        const screenshot = await page.screenshot({fullPage: true});
+        results[nextPath] = {html, screenshot};
+        logFn(`Fetched and stored content for ${nextPath}`);
+      } catch (error) {
+        logFn(`Error fetching ${fullUrl}: ${error}`);
+      }
     }
+
+    await page.close();
   }
+
+  await Promise.all(Array.from({length: Math.min(concurrency, paths.length)}, worker));
 
   await browser.close();
   return results;

--- a/src/core/reporter.ts
+++ b/src/core/reporter.ts
@@ -2,7 +2,7 @@ import {diffWords} from 'diff';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-interface PageResult {
+export interface PageResult {
   htmlDiff: null | number;
   htmlDiffPath?: string;
   matchScore: number;


### PR DESCRIPTION
## Summary
- enable concurrent page fetching for faster diffs
- parallelize site comparison logic
- export `PageResult` type for reuse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a0ac9bea083248d3a977929f7f0c5