### PR TITLE
fix: avoid networkidle hang during fetch

### DIFF
--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -22,7 +22,9 @@ export async function fetchPages(
     page.setDefaultNavigationTimeout(60_000); // 60 seconds
 
     try {
-      await page.goto(fullUrl, {waitUntil: 'networkidle'});
+      // Using 'load' instead of 'networkidle' avoids hanging on pages
+      // that keep long-lived network connections (analytics, streaming, etc.).
+      await page.goto(fullUrl, {waitUntil: 'load'});
       const html = await page.content();
       const screenshot = await page.screenshot({fullPage: true});
       results[path] = {html, screenshot};


### PR DESCRIPTION
## Summary
- avoid hanging on pages with long-lived network activity by waiting for `load` instead of `networkidle` during page fetch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68924b3bbdb483248be7701d8882ea8d