### PR TITLE
Handle mismatched screenshot heights in visual tests

### DIFF
--- a/src/core/comparator.ts
+++ b/src/core/comparator.ts
@@ -139,12 +139,23 @@ export async function compareSites(
               `[DIFF] Screenshot size mismatch for ${pathKey}: prod=${prodPng.width}x${prodPng.height}, ` +
               `test=${testPng.width}x${testPng.height}`,
             );
+
+            const maxWidth = Math.max(prodPng.width, testPng.width);
+            const maxHeight = Math.max(prodPng.height, testPng.height);
+
+            const prodAligned = new PNG({height: maxHeight, width: maxWidth});
+            const testAligned = new PNG({height: maxHeight, width: maxWidth});
+
+            PNG.bitblt(prodPng, prodAligned, 0, 0, prodPng.width, prodPng.height, 0, 0);
+            PNG.bitblt(testPng, testAligned, 0, 0, testPng.width, testPng.height, 0, 0);
+
+            prodPng = prodAligned;
+            testPng = testAligned;
           }
 
-          const width = Math.min(prodPng.width, testPng.width);
-          const height = Math.min(prodPng.height, testPng.height);
+            const {height, width} = prodPng;
 
-          const diff = new PNG({height, width});
+            const diff = new PNG({height, width});
           const mismatch = pixelmatch(
             prodPng.data,
             testPng.data,


### PR DESCRIPTION
## Summary
- pad screenshots to a common size before diffing so pages with different dimensions are still compared
- test that mismatched screenshot sizes no longer throw errors and still generate a diff image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68929497c4dc8324bd061a58b6a97845